### PR TITLE
crt: add confirm option

### DIFF
--- a/crt/src/crt/cmds/manifest.py
+++ b/crt/src/crt/cmds/manifest.py
@@ -1058,6 +1058,13 @@ def cmd_manifest_publish(
     default=False,
     help="Only print release notes to stdout.",
 )
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Automatic yes to prompts",
+)
 @with_patches_repo_path
 def cmd_manifest_release_notes(
     patches_repo_path: Path,
@@ -1065,6 +1072,7 @@ def cmd_manifest_release_notes(
     cephadm_loc: str | None,
     image_loc: str | None,
     to_stdout: bool,
+    assume_yes: bool,
 ) -> None:
     try:
         manifest = load_manifest_by_name_or_uuid(patches_repo_path, name_or_uuid)
@@ -1083,8 +1091,12 @@ def cmd_manifest_release_notes(
         print(txt)
 
     dst_path = patches_repo_path / "release-notes" / f"{manifest.name}.md"
-    if dst_path.exists() and not click.confirm(
-        "Release notes file exists. Overwrite?", default=False, prompt_suffix=""
+    if (
+        dst_path.exists()
+        and not assume_yes
+        and not click.confirm(
+            "Release notes file exists. Overwrite?", default=False, prompt_suffix=""
+        )
     ):
         pinfo(f"not writing release notes to {dst_path}")
         sys.exit(0)

--- a/crt/src/crt/cmds/patchset.py
+++ b/crt/src/crt/cmds/patchset.py
@@ -334,6 +334,13 @@ def cmd_patchset() -> None:
     metavar="NAME",
     help="Release associated with this patch set.",
 )
+@click.option(
+    "--no",
+    "assume_no",
+    is_flag=True,
+    default=False,
+    help="Automatic no to prompts",
+)
 @with_patches_repo_path
 def cmd_patchset_create(
     patches_repo_path: Path,
@@ -342,6 +349,7 @@ def cmd_patchset_create(
     patchset_title: str | None,
     patchset_desc: str | None,
     release_name: str | None,
+    assume_no: bool,
 ) -> None:
     print("prompt?")
     if not patchset_title:
@@ -357,7 +365,9 @@ def cmd_patchset_create(
         sys.exit(errno.EINVAL)
 
     author_info = f"{author_name} <{author_email}>"
-    if not patchset_desc and click.confirm("Add a description?", default=False):
+    if not patchset_desc and (
+        not assume_no and click.confirm("Add a description?", default=False)
+    ):
         try:
             desc_msg = (
                 click.edit(
@@ -507,6 +517,13 @@ def cmd_patchset_info(patches_repo_path: Path, patchset_uuid: uuid.UUID) -> None
     metavar="NAME",
     help="Branch on which to find patches.",
 )
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Automatic yes to prompts",
+)
 @click.argument(
     "patch_sha",
     metavar="SHA|SHA1..SHA2 [...]",
@@ -523,6 +540,7 @@ def cmd_patchset_add(
     patchset_uuid: uuid.UUID,
     gh_repo: str,
     patches_branch: str,
+    assume_yes: bool,
     patch_sha: list[str],
 ) -> None:
     if not ctx.github_token:
@@ -715,7 +733,9 @@ def cmd_patchset_add(
                 patch_lst_table.add_row(sha, title)
 
         console.print(Padding(patch_lst_table, (1, 0, 1, 0)))
-        if not click.confirm("Add above patches to patch set?", prompt_suffix=" "):
+        if not assume_yes and not click.confirm(
+            "Add above patches to patch set?", prompt_suffix=" "
+        ):
             pwarn("Aborted")
             sys.exit(0)
 
@@ -753,6 +773,13 @@ def cmd_patchset_add(
     required=True,
     help="Patch set UUID.",
 )
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Automatic yes to prompts",
+)
 @with_patches_repo_path
 @pass_ctx
 def cmd_patchset_publish(
@@ -760,6 +787,7 @@ def cmd_patchset_publish(
     patches_repo_path: Path,
     ceph_repo_path: Path,
     patchset_uuid: uuid.UUID,
+    assume_yes: bool,
 ) -> None:
     if not ctx.github_token:
         perror("missing GitHub token")
@@ -786,7 +814,9 @@ def cmd_patchset_publish(
         sys.exit(errno.EINVAL)
 
     console.print(_gen_rich_patchset_info(patchset))
-    if not click.confirm("Publish above patch set?", prompt_suffix=" "):
+    if not assume_yes and not click.confirm(
+        "Publish above patch set?", prompt_suffix=" "
+    ):
         pwarn("Aborted")
         sys.exit(0)
 
@@ -830,8 +860,17 @@ def cmd_patchset_publish(
     required=True,
     help="Patch set UUID.",
 )
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Automatic yes to prompts",
+)
 @with_patches_repo_path
-def cmd_patchset_remove(patches_repo_path: Path, patchset_uuid: uuid.UUID) -> None:
+def cmd_patchset_remove(
+    patches_repo_path: Path, patchset_uuid: uuid.UUID, assume_yes: bool
+) -> None:
     patchset_meta_path = get_patchset_meta_path(patches_repo_path, patchset_uuid)
     if not patchset_meta_path.exists():
         perror(f"patch set '{patchset_uuid}' does not exist")
@@ -852,7 +891,9 @@ def cmd_patchset_remove(patches_repo_path: Path, patchset_uuid: uuid.UUID) -> No
         sys.exit(errno.EINVAL)
 
     console.print(_gen_rich_patchset_info(patchset))
-    if not click.confirm("Remove above patch set?", prompt_suffix=" "):
+    if not assume_yes and not click.confirm(
+        "Remove above patch set?", prompt_suffix=" "
+    ):
         pwarn("Aborted")
         sys.exit(0)
 


### PR DESCRIPTION
crt: introduce confirmation options

* what: 
    introduce --yes and --no options to crt subcommands that might ask for confirmation during execution.

* why: 
    allow the tool to run non-interactively. in scenarios like testing and automation, it is impossible to provide user input manually.