### PR TITLE
Sign image only if keys are present

### DIFF
--- a/cbscore/src/cbscore/images/signing.py
+++ b/cbscore/src/cbscore/images/signing.py
@@ -36,6 +36,36 @@ class SigningError(CESError):
         return f"Signing Error: {self.msg}"
 
 
+def can_sign(registry: str, img: str, secrets: SecretsMgr, transit: str) -> bool:
+    if not secrets.has_vault():
+        msg = "no vault configured, can't sign image"
+        logger.debug(msg)
+        return False
+
+    assert secrets.vault is not None
+
+    if not secrets.has_transit_key(transit):
+        msg = f"vault transit key '{transit}' not found, can't sign image"
+        logger.debug(msg)
+        return False
+
+    try:
+        _ = secrets.registry_creds(registry)
+    except SecretsMgrError as e:
+        msg = f"unable to obtain registry credentials for '{registry}': {e}"
+        logger.debug(msg)
+        return False
+
+    try:
+        _ = secrets.transit(transit)
+    except SecretsMgrError as e:
+        msg = f"unable to obtain transit key '{transit}': {e}"
+        logger.debug(msg)
+        return False
+    
+    return True
+
+
 def sign(
     registry: str, img: str, secrets: SecretsMgr, transit: str
 ) -> tuple[int, str, str]:

--- a/cbscore/src/cbscore/images/skopeo.py
+++ b/cbscore/src/cbscore/images/skopeo.py
@@ -24,7 +24,7 @@ from cbscore.errors import CESError, UnknownRepositoryError
 from cbscore.images import get_image_name
 from cbscore.images import logger as parent_logger
 from cbscore.images.errors import ImageNotFoundError, SkopeoError
-from cbscore.images.signing import sign
+from cbscore.images.signing import can_sign, sign
 from cbscore.utils import CmdArgs, Password, run_cmd
 from cbscore.utils.containers import get_container_image_base_uri
 from cbscore.utils.secrets import SecretsMgrError
@@ -99,17 +99,18 @@ def skopeo_copy(
 
     logger.info(f"copied '{src}' to '{dst}'")
 
-    try:
-        retcode, out, err = sign(dst_registry, dst, secrets, transit)
-    except SkopeoError as e:
-        logger.exception(f"error signing image '{dst}'")
-        raise e  # noqa: TRY201
-
-    if retcode != 0:
-        logger.error(f"error signing image '{dst}': {err}")
-        raise SkopeoError()
-
-    logger.info(f"signed image '{dst}': {out}")
+    if can_sign(dst_registry, dst, secrets, transit):
+        try:
+            retcode, out, err = sign(dst_registry, dst, secrets, transit)
+        except SkopeoError as e:
+            logger.exception(f"error signing image '{dst}'")
+            raise e  # noqa: TRY201
+    
+        if retcode != 0:
+            logger.error(f"error signing image '{dst}': {err}")
+            raise SkopeoError()
+    
+        logger.info(f"signed image '{dst}': {out}")
 
 
 def skopeo_inspect(img: str, secrets: SecretsMgr) -> str:


### PR DESCRIPTION
* what: check if the vault and transit key is available in the secrets file. retrieve user credentials for the registry and transit. if all credentials are available, sign the image with cosign; otherwise, skip signing.

* why: run cbsbuild locally for testing, the image signing step must be skipped if keys are missing. see https://github.com/clyso/cbs/issues/24