### PR TITLE
cbscore: support local registries and container reuse

### DIFF
--- a/cbscore/src/cbscore/builder/builder.py
+++ b/cbscore/src/cbscore/builder/builder.py
@@ -79,7 +79,7 @@ class Builder:
         *,
         skip_build: bool = False,
         force: bool = False,
-        tls_verify: bool = True
+        tls_verify: bool = True,
     ) -> None:
         self.desc = desc
         self.config = config

--- a/cbscore/src/cbscore/builder/prepare.py
+++ b/cbscore/src/cbscore/builder/prepare.py
@@ -104,23 +104,24 @@ async def prepare_builder() -> None:
             logger.error(f"error installing builder packages: {stderr}")
             raise BuilderError(msg="unable to install dependencies")
 
-        # install cosign rpm
-        rc, stdout, stderr = await async_run_cmd(
-            [
-                "rpm",
-                "-Uvh",
-                "https://github.com/sigstore/cosign/releases/download/v2.4.3/"
-                + "cosign-2.4.3-1.x86_64.rpm",
-            ],
-        )
-        logger.debug(stdout)
-        if rc == 2 and re.match(".*already installed.*", stderr):
-            msg = f'skip install cosign. allready installed'
-            logger.debug(msg)
-        elif rc != 0:
-            msg = f"error installing cosign package: {stderr}"
-            logger.error(msg)
-            raise BuilderError(msg)
+        # install cosign rpm if not already installed
+        rc, _, _ = await async_run_cmd(["rpm", "-q", "cosign"])
+        if rc != 0:
+            rc, stdout, stderr = await async_run_cmd(
+                [
+                    "rpm",
+                    "-Uvh",
+                    "https://github.com/sigstore/cosign/releases/download/v2.4.3/"
+                    + "cosign-2.4.3-1.x86_64.rpm",
+                ],
+            )
+            logger.debug(stdout)
+            if rc != 0:
+                msg = f"error installing cosign package: {stderr}"
+                logger.error(msg)
+                raise BuilderError(msg)
+        else:
+            logger.debug("skip install cosign. already installed")
     except CommandError as e:
         logger.exception("unable to run 'dnf'")
         raise BuilderError(msg=f"error running 'dnf': {e}") from e

--- a/cbscore/src/cbscore/images/skopeo.py
+++ b/cbscore/src/cbscore/images/skopeo.py
@@ -16,6 +16,7 @@
 #
 # pyright: reportAny=false, reportUnknownArgumentType=false
 
+import errno
 import re
 
 import pydantic
@@ -147,7 +148,11 @@ def skopeo_inspect(img: str, secrets: SecretsMgr, *, tls_verify: bool = True) ->
 
     if retcode != 0:
         msg = f"error inspecting image '{img}': {err}"
-        if retcode == 2 or re.match(r".*not\s+found.*", err):
+        # Handle "image not found" across different Skopeo versions:
+        # - Newer versions of Skopeo explicitly return exit code 2.
+        # - Older versions return a generic error code but include "not found" in
+        #   stderr.
+        if retcode == errno.ENOENT or re.match(r".*not\s+found.*", err):
             logger.debug(msg)
             raise ImageNotFoundError(img) from None
         logger.error(msg)

--- a/cbscore/src/cbscore/runner.py
+++ b/cbscore/src/cbscore/runner.py
@@ -279,6 +279,9 @@ async def runner(
     if force:
         podman_args.append("--force")
 
+    if not tls_verify:
+        podman_args.append("--tls-verify=false")
+
     ctr_name = run_name if run_name else gen_run_name()
 
     report_host_path = config.paths.scratch / "build-report.json"


### PR DESCRIPTION
* what: 
  add flag to bypass tls certificate verification for skopeo. check 
  skopeo return code when finding an image on the registry. 
  ignore rpm install failure if the package is already installed.

* why: 
  local container registries don't need valid tls certificates or may 
  use self-signed ones. skopeo verifies certificates by default unless 
  --tls-verify=false is passed.

* note: 
  this also makes the container reusable for debugging. currently, 
  rpm install fails with return code 2 if the package is already installed. 
  in a production environment, containers are generated from scratch, 
  so this issue does not arise.