### PR TITLE
cbsd: add pytest and some test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,32 @@ We will also find a `podman-compose.cbs.yaml` file, which will set up a local
 `cbs` -- server, worker, and the required `redis` broker for the server's work
 queue. Using the `do-cbs-compose.sh` script we can easily run this setup.
 
+## Development
+
+Requires Python 3.13+ and [uv](https://docs.astral.sh/uv/).
+
+```bash
+# Install all dependencies
+uv sync
+
+# Lint and format
+uv run ruff check
+uv run ruff format --check
+
+# Type check
+uv run basedpyright .
+```
+
+### Running tests
+
+```bash
+# Install all workspace packages + test dependencies
+uv sync --all-packages --group test
+
+# Run the test suite
+uv run pytest cbsd/tests/ -v
+```
+
 ## Contributing
 
 We haven't quite defined all the requirements for contributing to this

--- a/cbsd/tests/__init__.py
+++ b/cbsd/tests/__init__.py
@@ -1,0 +1,12 @@
+# CBS service daemon - tests - shared fixtures
+# Copyright (C) 2026  Clyso GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.

--- a/cbsd/tests/conftest.py
+++ b/cbsd/tests/conftest.py
@@ -1,0 +1,62 @@
+# CBS service daemon - tests - shared fixtures
+# Copyright (C) 2026  Clyso GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+from typing import cast
+
+import pytest
+import yaml
+from cbslib.config.config import Config
+from cbslib.config.server import ServerConfig, ServerSecretsConfig
+from cbslib.core.permissions import Permissions
+
+
+def permissions_from_yaml(yaml_str: str) -> Permissions:
+    """Build a Permissions object from an inline YAML string."""
+    data = cast(object, yaml.safe_load(yaml_str))
+    return Permissions.model_validate(data)
+
+
+@pytest.fixture
+def mock_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Config:
+    """
+    Provide a minimal Config with a test token secret key.
+
+    Patches `cbslib.config.config._config` so that `get_config()` returns
+    this config without needing real files or env vars.
+    """
+    import cbslib.config.config as config_mod
+
+    cfg = Config(
+        server=ServerConfig(
+            cert=tmp_path / "cert.pem",
+            key=tmp_path / "key.pem",
+            db=tmp_path / "test.db",
+            permissions=tmp_path / "permissions.yaml",
+            secrets=ServerSecretsConfig(
+                oauth2_secrets_file=str(tmp_path / "oauth2.json"),
+                session_secret_key=secrets.token_hex(32),
+                token_secret_key=secrets.token_hex(32),
+                token_secret_ttl_minutes=60,
+            ),
+            logs=tmp_path / "logs",
+        ),
+        broker_url="redis://localhost:6379/0",
+        results_backend_url="redis://localhost:6379/1",
+        redis_backend_url="redis://localhost:6379/2",
+    )
+    monkeypatch.setattr(config_mod, "_config", cfg)
+    return cfg

--- a/cbsd/tests/test_auth.py
+++ b/cbsd/tests/test_auth.py
@@ -1,0 +1,103 @@
+# CBS service daemon - tests - auth tokens
+# Copyright (C) 2026  Clyso GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+from __future__ import annotations
+
+import secrets
+
+import pyseto
+import pytest
+from cbslib.auth.auth import UnauthorizedTokenError, token_create, token_decode
+from cbslib.config.config import Config
+
+# ===========================================================================
+# Token roundtrip
+# ===========================================================================
+
+
+class TestTokenRoundtrip:
+    """Token create -> decode roundtrip."""
+
+    def test_create_then_decode_preserves_email(self, mock_config: Config) -> None:
+        _ = mock_config  # fixture used for side-effects (patches global config)
+        token = token_create("user@example.com")
+        decoded = token_decode(token.token.get_secret_value().decode())
+        assert decoded.user == "user@example.com"
+
+    def test_expiration_set_when_ttl_configured(self, mock_config: Config) -> None:
+        _ = mock_config  # fixture used for side-effects (patches global config)
+        token = token_create("user@example.com")
+        assert token.info.expires is not None
+
+    def test_expiration_none_when_ttl_zero(
+        self, mock_config: Config, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        assert mock_config.server is not None
+        monkeypatch.setattr(mock_config.server.secrets, "token_secret_ttl_minutes", 0)
+        token = token_create("user@example.com")
+        assert token.info.expires is None
+
+
+# ===========================================================================
+# Invalid tokens
+# ===========================================================================
+
+
+@pytest.mark.usefixtures("mock_config")
+class TestInvalidTokens:
+    """Decoding invalid tokens must raise UnauthorizedTokenError."""
+
+    def test_garbage_string_raises(self) -> None:
+        with pytest.raises(UnauthorizedTokenError):
+            _ = token_decode("totally-not-a-valid-token")
+
+    def test_different_key_raises(self) -> None:
+        """A token signed with a different key cannot be decoded."""
+        different_key = pyseto.Key.new(
+            version=4,
+            purpose="local",
+            key=secrets.token_hex(32),
+        )
+        foreign_token: bytes = pyseto.encode(
+            different_key,
+            payload=b'{"user":"evil@example.com","expires":null}',
+        )
+        with pytest.raises(UnauthorizedTokenError):
+            _ = token_decode(foreign_token.decode())
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(UnauthorizedTokenError):
+            _ = token_decode("")
+
+
+# ===========================================================================
+# Malformed payload
+# ===========================================================================
+
+
+class TestMalformedPayload:
+    """Valid PASETO envelope but non-JSON payload."""
+
+    def test_non_json_payload_raises(self, mock_config: Config) -> None:
+        assert mock_config.server is not None
+        key = pyseto.Key.new(
+            version=4,
+            purpose="local",
+            key=mock_config.server.secrets.token_secret_key,
+        )
+        bad_token: bytes = pyseto.encode(
+            key,
+            payload=b"this is not json",
+        )
+        with pytest.raises(UnauthorizedTokenError):
+            _ = token_decode(bad_token.decode())

--- a/cbsd/tests/test_permissions.py
+++ b/cbsd/tests/test_permissions.py
@@ -1,0 +1,576 @@
+# CBS service daemon - tests - permissions
+# Copyright (C) 2026  Clyso GmbH
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pydantic
+import pytest
+from cbslib.core.permissions import (
+    AuthCapsType,
+    AuthorizationCaps,
+    AuthorizationGroup,
+    Permissions,
+    ProjectAuthorizationEntry,
+    RegistryAuthorizationEntry,
+    RepositoryAuthorizationEntry,
+    RoutesCaps,
+    RoutesCapsType,
+    UserAuthorizationRule,
+)
+
+from tests.conftest import permissions_from_yaml
+
+# ---------------------------------------------------------------------------
+# Helpers for caps string validation via pydantic
+# ---------------------------------------------------------------------------
+
+
+class _AuthCapsModel(pydantic.BaseModel):
+    caps: AuthCapsType
+
+
+class _RoutesCapsModel(pydantic.BaseModel):
+    caps: RoutesCapsType
+
+
+def _auth_caps(strs: list[str]) -> AuthorizationCaps:
+    return _AuthCapsModel.model_validate({"caps": strs}).caps
+
+
+def _routes_caps(strs: list[str]) -> RoutesCaps:
+    return _RoutesCapsModel.model_validate({"caps": strs}).caps
+
+
+# ===========================================================================
+# Caps string expansion
+# ===========================================================================
+
+
+class TestCapsStringExpansion:
+    """Tests for the `_caps_from_str_lst_for` conversion logic."""
+
+    def test_all_expands_to_every_auth_flag(self) -> None:
+        caps = _auth_caps(["all"])
+        for member in AuthorizationCaps:
+            assert member in caps
+
+    def test_star_regex_expands_same_as_all(self) -> None:
+        assert _auth_caps([".*"]) == _auth_caps(["all"])
+
+    def test_builds_star_expands_only_builds(self) -> None:
+        caps = _auth_caps(["builds:.*"])
+        for member in AuthorizationCaps:
+            name = member.get_canonical_name()
+            if name.startswith("builds:"):
+                assert member in caps
+            else:
+                assert member not in caps
+
+    def test_negation_removes_single_flag(self) -> None:
+        caps = _auth_caps(["all", "-builds:revoke:any"])
+        assert AuthorizationCaps.BUILDS_REVOKE_ANY not in caps
+        assert AuthorizationCaps.BUILDS_CREATE in caps
+        assert AuthorizationCaps.PROJECT_LIST in caps
+
+    def test_all_minus_builds_star(self) -> None:
+        caps = _auth_caps(["all", "-builds:.*"])
+        for member in AuthorizationCaps:
+            name = member.get_canonical_name()
+            if name.startswith("builds:"):
+                assert member not in caps
+            else:
+                assert member in caps
+
+    def test_invalid_regex_raises_value_error(self) -> None:
+        with pytest.raises(pydantic.ValidationError):
+            _ = _auth_caps(["[invalid"])
+
+    def test_routes_all_expands_to_every_route_flag(self) -> None:
+        caps = _routes_caps(["all"])
+        for member in RoutesCaps:
+            assert member in caps
+
+    def test_routes_star_same_as_all(self) -> None:
+        assert _routes_caps([".*"]) == _routes_caps(["all"])
+
+    def test_routes_negation(self) -> None:
+        caps = _routes_caps(["all", "-routes:auth:permissions"])
+        assert RoutesCaps.ROUTES_AUTH_PERMISSIONS not in caps
+        assert RoutesCaps.ROUTES_AUTH_LOGIN in caps
+
+    def test_routes_prefix_star_with_negation(self) -> None:
+        caps = _routes_caps(["routes:.*", "-routes:auth:permissions"])
+        assert RoutesCaps.ROUTES_AUTH_PERMISSIONS not in caps
+        assert RoutesCaps.ROUTES_BUILDS_NEW in caps
+
+
+# ===========================================================================
+# Caps serialization roundtrip
+# ===========================================================================
+
+
+class TestCapsSerialization:
+    """Caps -> JSON -> back roundtrip preserves the value."""
+
+    def test_auth_caps_roundtrip(self) -> None:
+        original = _AuthCapsModel(
+            caps=AuthorizationCaps.BUILDS_CREATE | AuthorizationCaps.BUILDS_LIST_OWN,
+        )
+        json_str = original.model_dump_json()
+        restored = _AuthCapsModel.model_validate_json(json_str)
+        assert original.caps == restored.caps
+
+    def test_routes_caps_roundtrip(self) -> None:
+        original = _RoutesCapsModel(
+            caps=RoutesCaps.ROUTES_BUILDS_NEW | RoutesCaps.ROUTES_AUTH_LOGIN,
+        )
+        json_str = original.model_dump_json()
+        restored = _RoutesCapsModel.model_validate_json(json_str)
+        assert original.caps == restored.caps
+
+    def test_auth_caps_all_roundtrip(self) -> None:
+        original = _AuthCapsModel.model_validate({"caps": ["all"]})
+        json_str = original.model_dump_json()
+        restored = _AuthCapsModel.model_validate_json(json_str)
+        assert original.caps == restored.caps
+
+
+# ===========================================================================
+# Permissions.load()
+# ===========================================================================
+
+_MINIMAL_YAML = """\
+groups: {}
+rules: []
+"""
+
+
+class TestPermissionsLoad:
+    """Tests for Permissions.load() from file."""
+
+    def test_valid_yaml_loads(self, tmp_path: Path) -> None:
+        f = tmp_path / "perms.yaml"
+        _ = f.write_text(_MINIMAL_YAML)
+        perms = Permissions.load(f)
+        assert perms.groups == {}
+        assert perms.rules == []
+
+    def test_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            _ = Permissions.load(tmp_path / "nonexistent.yaml")
+
+    def test_unsupported_extension_raises_value_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "perms.txt"
+        _ = f.write_text(_MINIMAL_YAML)
+        with pytest.raises(ValueError):
+            _ = Permissions.load(f)
+
+    def test_malformed_yaml_raises_value_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "perms.yaml"
+        _ = f.write_text("groups: [invalid\n  yaml")
+        with pytest.raises(ValueError):
+            _ = Permissions.load(f)
+
+    def test_invalid_schema_raises_value_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "perms.yaml"
+        _ = f.write_text("groups: 42\nrules: 'nope'\n")
+        with pytest.raises(ValueError):
+            _ = Permissions.load(f)
+
+
+# ===========================================================================
+# Default YAML fixture — shared across permission check tests
+# ===========================================================================
+
+_DEFAULT_YAML = r"""
+groups:
+  admin:
+    name: admin
+    authorized_for:
+      - type: project
+        pattern: '.*'
+        caps:
+          - '.*'
+      - type: registry
+        pattern: '.*'
+      - type: repository
+        pattern: '.*'
+      - type: routes
+        caps:
+          - '.*'
+
+  development:
+    name: development
+    authorized_for:
+      - type: project
+        pattern: '^dev/.*$'
+        caps:
+          - project:list
+          - builds:create
+          - builds:revoke:own
+          - builds:list:own
+          - builds:list:any
+      - type: registry
+        pattern: '^registry\.domain\.tld/dev/.*$'
+      - type: repository
+        pattern: '^https?://git\.domain\.tld/dev/.*$'
+      - type: routes
+        caps:
+          - '.*'
+          - -routes:auth:permissions
+
+  all:
+    name: all
+    authorized_for:
+      - type: project
+        pattern: '.*'
+        caps:
+          - project:list
+          - builds:list:any
+
+rules:
+  - user_pattern: '^.*@domain\.tld$'
+    groups:
+      - all
+  - user_pattern: '^admin@domain\.tld$'
+    groups:
+      - admin
+  - user_pattern: '^dev-.*@domain\.tld$'
+    groups:
+      - all
+      - development
+"""
+
+
+@pytest.fixture
+def default_perms() -> Permissions:
+    return permissions_from_yaml(_DEFAULT_YAML)
+
+
+# ===========================================================================
+# is_authorized_for_project
+# ===========================================================================
+
+
+class TestIsAuthorizedForProject:
+    """Tests for Permissions.is_authorized_for_project()."""
+
+    def test_catch_all_rule_grants_limited_caps(
+        self, default_perms: Permissions
+    ) -> None:
+        assert default_perms.is_authorized_for_project(
+            "foo@domain.tld",
+            "whatever/project",
+            AuthorizationCaps.PROJECT_LIST | AuthorizationCaps.BUILDS_LIST_ANY,
+        )
+
+    def test_catch_all_rule_denies_caps_not_granted(
+        self, default_perms: Permissions
+    ) -> None:
+        assert not default_perms.is_authorized_for_project(
+            "foo@domain.tld",
+            "whatever/project",
+            AuthorizationCaps.BUILDS_CREATE,
+        )
+
+    def test_admin_gets_all_project_caps(self, default_perms: Permissions) -> None:
+        assert default_perms.is_authorized_for_project(
+            "admin@domain.tld",
+            "other/project",
+            AuthorizationCaps.PROJECT_MANAGE
+            | AuthorizationCaps.BUILDS_CREATE
+            | AuthorizationCaps.BUILDS_REVOKE_ANY
+            | AuthorizationCaps.BUILDS_LIST_ANY,
+        )
+
+    def test_dev_user_authorized_for_dev_project(
+        self, default_perms: Permissions
+    ) -> None:
+        assert default_perms.is_authorized_for_project(
+            "dev-bar@domain.tld",
+            "dev/qwerty",
+            AuthorizationCaps.PROJECT_LIST
+            | AuthorizationCaps.BUILDS_CREATE
+            | AuthorizationCaps.BUILDS_REVOKE_OWN
+            | AuthorizationCaps.BUILDS_LIST_OWN,
+        )
+
+    def test_dev_user_denied_admin_caps_on_dev_project(
+        self, default_perms: Permissions
+    ) -> None:
+        assert not default_perms.is_authorized_for_project(
+            "dev-bar@domain.tld",
+            "dev/qwerty",
+            AuthorizationCaps.PROJECT_MANAGE | AuthorizationCaps.BUILDS_REVOKE_ANY,
+        )
+
+    def test_unknown_user_denied(self, default_perms: Permissions) -> None:
+        assert not default_perms.is_authorized_for_project(
+            "nobody@other.tld",
+            "any/project",
+            AuthorizationCaps.PROJECT_LIST,
+        )
+
+
+# ===========================================================================
+# Multi-rule evaluation — core of permissions bug investigation
+# ===========================================================================
+
+
+class TestMultiRuleEvaluation:
+    """
+    Verify that multiple matching rules are all evaluated.
+
+    This tests the scenario where a user matches a catch-all rule with limited
+    caps AND a more specific rule with full caps. The second rule must still
+    grant access even though the first rule's limited caps didn't.
+    """
+
+    def test_admin_matches_catch_all_then_admin_rule(
+        self, default_perms: Permissions
+    ) -> None:
+        """
+        admin@domain.tld matches the catch-all (limited caps) AND admin rule.
+
+        The admin rule must grant PROJECT_MANAGE even though the catch-all doesn't.
+        """
+        assert default_perms.is_authorized_for_project(
+            "admin@domain.tld",
+            "any/project",
+            AuthorizationCaps.PROJECT_MANAGE,
+        )
+
+    def test_dev_user_gets_caps_from_both_all_and_dev_groups(
+        self, default_perms: Permissions
+    ) -> None:
+        """
+        dev-x@domain.tld has both 'all' and 'development' groups.
+
+        Caps from both groups should be aggregated via OR within a single rule.
+        """
+        assert default_perms.is_authorized_for_project(
+            "dev-x@domain.tld",
+            "dev/test",
+            AuthorizationCaps.BUILDS_CREATE | AuthorizationCaps.BUILDS_LIST_ANY,
+        )
+
+    def test_catch_all_alone_does_not_grant_admin_caps(
+        self, default_perms: Permissions
+    ) -> None:
+        """A user matching only the catch-all rule should not get admin caps."""
+        assert not default_perms.is_authorized_for_project(
+            "regular@domain.tld",
+            "some/project",
+            AuthorizationCaps.PROJECT_MANAGE,
+        )
+
+
+# ===========================================================================
+# is_authorized_for_route
+# ===========================================================================
+
+
+class TestIsAuthorizedForRoute:
+    """Tests for Permissions.is_authorized_for_route()."""
+
+    def test_admin_gets_all_route_caps(self, default_perms: Permissions) -> None:
+        assert default_perms.is_authorized_for_route(
+            "admin@domain.tld",
+            caps=RoutesCaps.ROUTES_AUTH_PERMISSIONS | RoutesCaps.ROUTES_AUTH_LOGIN,
+        )
+
+    def test_dev_gets_routes_except_excluded(self, default_perms: Permissions) -> None:
+        assert default_perms.is_authorized_for_route(
+            "dev-foo@domain.tld",
+            caps=RoutesCaps.ROUTES_AUTH_LOGIN,
+        )
+
+    def test_dev_denied_excluded_route(self, default_perms: Permissions) -> None:
+        assert not default_perms.is_authorized_for_route(
+            "dev-foo@domain.tld",
+            caps=RoutesCaps.ROUTES_AUTH_PERMISSIONS,
+        )
+
+    def test_unknown_user_denied(self, default_perms: Permissions) -> None:
+        assert not default_perms.is_authorized_for_route(
+            "nobody@other.tld",
+            caps=RoutesCaps.ROUTES_AUTH_LOGIN,
+        )
+
+
+# ===========================================================================
+# is_authorized_for_registry
+# ===========================================================================
+
+
+class TestIsAuthorizedForRegistry:
+    """Tests for Permissions.is_authorized_for_registry()."""
+
+    def test_admin_authorized_for_any_registry(
+        self, default_perms: Permissions
+    ) -> None:
+        assert default_perms.is_authorized_for_registry(
+            "admin@domain.tld", "any.registry.io/foo"
+        )
+
+    def test_dev_authorized_for_dev_registry(self, default_perms: Permissions) -> None:
+        assert default_perms.is_authorized_for_registry(
+            "dev-foo@domain.tld", "registry.domain.tld/dev/myimg"
+        )
+
+    def test_dev_denied_non_dev_registry(self, default_perms: Permissions) -> None:
+        assert not default_perms.is_authorized_for_registry(
+            "dev-foo@domain.tld", "registry.domain.tld/prod/myimg"
+        )
+
+    def test_regular_user_denied_registry(self, default_perms: Permissions) -> None:
+        """The 'all' group has no registry entries, so regular users are denied."""
+        assert not default_perms.is_authorized_for_registry(
+            "regular@domain.tld", "any.registry.io/foo"
+        )
+
+
+# ===========================================================================
+# is_authorized_for_repository
+# ===========================================================================
+
+
+class TestIsAuthorizedForRepository:
+    """Tests for Permissions.is_authorized_for_repository()."""
+
+    def test_admin_authorized_for_any_repo(self, default_perms: Permissions) -> None:
+        assert default_perms.is_authorized_for_repository(
+            "admin@domain.tld", "https://github.com/anything"
+        )
+
+    def test_dev_authorized_for_dev_repo(self, default_perms: Permissions) -> None:
+        assert default_perms.is_authorized_for_repository(
+            "dev-foo@domain.tld", "https://git.domain.tld/dev/myrepo"
+        )
+
+    def test_dev_denied_non_dev_repo(self, default_perms: Permissions) -> None:
+        assert not default_perms.is_authorized_for_repository(
+            "dev-foo@domain.tld", "https://git.domain.tld/prod/myrepo"
+        )
+
+    def test_regular_user_denied_repository(self, default_perms: Permissions) -> None:
+        assert not default_perms.is_authorized_for_repository(
+            "regular@domain.tld", "https://github.com/anything"
+        )
+
+
+# ===========================================================================
+# Basic Permissions object construction (ported from _test_basic_permissions)
+# ===========================================================================
+
+
+class TestBasicPermissionsConstruction:
+    """Tests built from the ad-hoc _test_basic_permissions() assertions."""
+
+    @pytest.fixture
+    def basic_perms(self) -> Permissions:
+        auth = Permissions(groups={}, rules=[])
+        auth.groups["admin"] = AuthorizationGroup(
+            name="admin",
+            authorized_for=[
+                ProjectAuthorizationEntry(
+                    pattern=r".*",
+                    caps=AuthorizationCaps.PROJECT_MANAGE
+                    | AuthorizationCaps.PROJECT_LIST
+                    | AuthorizationCaps.BUILDS_CREATE
+                    | AuthorizationCaps.BUILDS_REVOKE_ANY
+                    | AuthorizationCaps.BUILDS_LIST_ANY,
+                ),
+                RegistryAuthorizationEntry(pattern=r".*"),
+                RepositoryAuthorizationEntry(pattern=r".*"),
+            ],
+        )
+        auth.groups["development"] = AuthorizationGroup(
+            name="development",
+            authorized_for=[
+                ProjectAuthorizationEntry(
+                    pattern=r"^dev/.*$",
+                    caps=AuthorizationCaps.PROJECT_LIST
+                    | AuthorizationCaps.BUILDS_CREATE
+                    | AuthorizationCaps.BUILDS_LIST_OWN
+                    | AuthorizationCaps.BUILDS_LIST_ANY
+                    | AuthorizationCaps.BUILDS_REVOKE_OWN,
+                ),
+                RegistryAuthorizationEntry(pattern=r"^registry\.example\.com/dev/.*$"),
+                RepositoryAuthorizationEntry(pattern=r"https?://github\.com/clyso/.*"),
+            ],
+        )
+        auth.groups["all"] = AuthorizationGroup(
+            name="all",
+            authorized_for=[
+                ProjectAuthorizationEntry(
+                    pattern=r".*",
+                    caps=AuthorizationCaps.PROJECT_LIST
+                    | AuthorizationCaps.BUILDS_LIST_OWN
+                    | AuthorizationCaps.BUILDS_LIST_ANY,
+                ),
+            ],
+        )
+        auth.rules.extend(
+            [
+                UserAuthorizationRule(user_pattern=r"^.*@domain\.tld$", groups=["all"]),
+                UserAuthorizationRule(
+                    user_pattern=r"^foo.bar@domain.tld$",
+                    groups=["development"],
+                ),
+                UserAuthorizationRule(
+                    user_pattern=r"^foo.baz@domain.tld$",
+                    groups=["admin"],
+                ),
+            ]
+        )
+        return auth
+
+    def test_dev_user_project_list_any(self, basic_perms: Permissions) -> None:
+        assert basic_perms.is_authorized_for_project(
+            "foo.bar@domain.tld", "foo/bar", AuthorizationCaps.PROJECT_LIST
+        )
+
+    def test_dev_user_dev_project_list(self, basic_perms: Permissions) -> None:
+        assert basic_perms.is_authorized_for_project(
+            "foo.bar@domain.tld",
+            "dev/foobar",
+            AuthorizationCaps.PROJECT_LIST,
+        )
+
+    def test_dev_user_combined_caps(self, basic_perms: Permissions) -> None:
+        assert basic_perms.is_authorized_for_project(
+            "foo.bar@domain.tld",
+            "dev/foobar",
+            AuthorizationCaps.BUILDS_CREATE | AuthorizationCaps.BUILDS_LIST_ANY,
+        )
+
+    def test_dev_user_denied_manage(self, basic_perms: Permissions) -> None:
+        assert not basic_perms.is_authorized_for_project(
+            "foo.bar@domain.tld",
+            "dev/foobar",
+            AuthorizationCaps.PROJECT_MANAGE,
+        )
+
+    def test_admin_user_full_caps(self, basic_perms: Permissions) -> None:
+        assert basic_perms.is_authorized_for_project(
+            "foo.baz@domain.tld",
+            "dev/foobar",
+            AuthorizationCaps.PROJECT_MANAGE
+            | AuthorizationCaps.PROJECT_LIST
+            | AuthorizationCaps.BUILDS_CREATE
+            | AuthorizationCaps.BUILDS_REVOKE_ANY
+            | AuthorizationCaps.BUILDS_LIST_ANY,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ members = ["cbscore", "cbsdcore", "cbsd", "cbc", "crt"]
 
 [dependency-groups]
 dev = ["basedpyright==1.37.1", "lefthook==2.0.15", "ruff==0.14.13"]
+test = ["pytest>=8.0", "pytest-asyncio>=0.25"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["cbsd/tests"]
 
 [tool.ruff.lint]
 select = [

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -10,5 +10,10 @@
     "**/node_modules"
   ],
   "baselineFile": ".basedpyright/baseline.json",
-  "extraPaths": ["cbscore/src", "crt/src"]
+  "extraPaths": [
+    "cbscore/src",
+    "crt/src",
+    "cbsd",
+    "cbc/src"
+  ]
 }

--- a/uv.lock
+++ b/uv.lock
@@ -660,6 +660,10 @@ dev = [
     { name = "lefthook" },
     { name = "ruff" },
 ]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
 
 [package.metadata]
 
@@ -668,6 +672,10 @@ dev = [
     { name = "basedpyright", specifier = "==1.37.1" },
     { name = "lefthook", specifier = "==2.0.15" },
     { name = "ruff", specifier = "==0.14.13" },
+]
+test = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25" },
 ]
 
 [[package]]
@@ -1013,6 +1021,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "iso8601"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1209,6 +1226,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1471,6 +1497,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/24/778932e72993b2feb9fcf8a809a4ef31ba68b62b1e3b8e8cc653b404882f/pyseto-1.9.1.tar.gz", hash = "sha256:678c41a00984736853038d78d02c70e65d125f72d5f4505ea7332f24ffa13134", size = 73495, upload-time = "2025-12-29T13:47:43.739Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/44/c8008d4c9ed7f0f749d6fdad4f7b0a2aaf4715311853b59527de0ee3fd1f/pyseto-1.9.1-py3-none-any.whl", hash = "sha256:7f62c63412707fbfe22659b97aacfc3d4a692f99e04b356da744e04ba3464bd1", size = 30652, upload-time = "2025-12-29T13:47:42.622Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds pytest support to the project, and introduces some tests for `cbsd/`.

This way we're moving away from kludge tests in modules' `__main__` functions, and into something a lot more predictable and usable.

This patch set was generated mostly by Claude Opus 4.6, with guidance by the submitter.

Signed-off-by: Joao Eduardo Luis \<joao@clyso.com>