### PR TITLE
fix: Wrong import of GitError #46

### DIFF
--- a/crt/src/crt/cmds/release.py
+++ b/crt/src/crt/cmds/release.py
@@ -20,7 +20,6 @@ from typing import cast
 import click
 import rich.box
 from cbscore.versions.utils import parse_version
-from git import GitError
 from rich.padding import Padding
 from rich.table import Table
 
@@ -28,6 +27,7 @@ from crt.cmds._common import CRTExitError, CRTProgress
 from crt.crtlib.errors.manifest import NoSuchManifestError
 from crt.crtlib.errors.release import NoSuchReleaseError
 from crt.crtlib.git_utils import (
+    GitError,
     GitFetchHeadNotFoundError,
     GitIsTagError,
     git_branch_from,


### PR DESCRIPTION
* what: change the import of `GitError` from `git` to `crt.crtlib.git_utils`

* why: fix for bug [Wrong import of GitError #46](https://github.com/clyso/cbs/issues/46)