### PR TITLE
cleanup: print statement 

### DIFF
--- a/crt/src/crt/cmds/patchset.py
+++ b/crt/src/crt/cmds/patchset.py
@@ -351,7 +351,6 @@ def cmd_patchset_create(
     release_name: str | None,
     assume_no: bool,
 ) -> None:
-    print("prompt?")
     if not patchset_title:
         patchset_title = cast(
             str | None, click.prompt("Patch set title", type=str, prompt_suffix=" > ")


### PR DESCRIPTION
* what: remove the leftover `print("prompt?")` statement.

* why: clean up code based on PR review feedback. see [#47](https://github.com/clyso/cbs/issues/47)