### PR TITLE
crt: fix strict Pyright type checking errors

### DIFF
--- a/cbscore/src/cbscore/images/signing.py
+++ b/cbscore/src/cbscore/images/signing.py
@@ -69,7 +69,7 @@ def _get_signing_params(
 
 def can_sign(registry: str, secrets: SecretsMgr, transit: str) -> bool:
     try:
-        _get_signing_params(registry, secrets, transit)
+        _ = _get_signing_params(registry, secrets, transit)
     except SigningError as e:
         logger.debug(e.msg)
         return False

--- a/crt/src/crt/cmds/manifest.py
+++ b/crt/src/crt/cmds/manifest.py
@@ -1171,15 +1171,15 @@ def _prepare_release_repo(
         release = load_release(ces_patch_path, release_name)
         release_repo_name = release.base_repo
 
-        git_prepare_remote(
+        _ = git_prepare_remote(
             ceph_repo_path, f"github.com/{release_repo_name}", release_repo_name, token
         )
         if remote_name != release_repo_name:
-            git_prepare_remote(
+            _ = git_prepare_remote(
                 ceph_repo_path, f"github.com/{remote_name}", remote_name, token
             )
-        git_push(ceph_repo_path, release_branch_name, remote_name)
-        git_push(ceph_repo_path, release_tag_name, remote_name)
+        _ = git_push(ceph_repo_path, release_branch_name, remote_name)
+        _ = git_push(ceph_repo_path, release_tag_name, remote_name)
     except GitError as e:
         perror(f"unable to prepare release repository: {e}")
         sys.exit(e.ec if e.ec else errno.ENOTRECOVERABLE)

--- a/crt/src/crt/crtlib/git_utils.py
+++ b/crt/src/crt/crtlib/git_utils.py
@@ -15,6 +15,7 @@ import logging
 import re
 import sys
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast, override
 
@@ -814,9 +815,8 @@ def git_format_patch(repo_path: Path, rev: SHA, *, base_rev: SHA | None = None) 
 def git_tag_exists_in_remote(repo_path: Path, remote_name: str, tag_name: str) -> bool:
     try:
         repo = git.Repo(repo_path)
-        raw_tag: str = repo.git.ls_remote(
-            "--tags", remote_name, f"refs/tags/{tag_name}"
-        )
+        ls_remote = cast(Callable[..., str], repo.git.ls_remote)
+        raw_tag: str = ls_remote("--tags", remote_name, f"refs/tags/{tag_name}")
         return bool(raw_tag.strip())
     except git.CommandError as e:
         msg = f"unable to execute git ls-remote --tags {remote_name} refs/tags/{tag_name}: {e}"


### PR DESCRIPTION
* what Assigned unused return values from `git_prepare_remote` and `git_push` to the discard variable `_` in `manifest.py`. Added a `typing.cast` to `Callable[..., str]` for `repo.git.ls_remote` in `git_utils.py`.

* why To resolve `reportUnusedCallResult` and `reportAny` errors flagged by stricter Pyright configurations. This explicitly acknowledges intentionally ignored return values and prevents untyped `Any` values from leaking out of the GitPython library, keeping the codebase strictly typed.

see [Ticket #55](https://github.com/clyso/cbs/issues/55)